### PR TITLE
Created some hooks for extendability

### DIFF
--- a/index.php
+++ b/index.php
@@ -351,9 +351,12 @@ function linkmarklet_post() {
     }
 
     // our final update
-    $post_ID = wp_update_post( $post );
 
+
+    do_action( 'linkmarklet-pre-post',$post_ID);
+    $post_ID = wp_update_post( $post );
     return $post_ID;
+    do_action( 'linkmarklet-after-post',$post_ID);
 }
 
 wp_enqueue_script( 'underscore' );
@@ -517,6 +520,7 @@ wp_enqueue_style( 'jquery-ui' );
             <label for="slug">Slug</label>
             <input type="text" name="slug" id="slug" value="<?php if( isset( $settings['prepopulate_slug'] ) ) { echo sanitize_title( $title ); } ?>" />
         </div>
+        <?php do_action('linkmarklet-form',$url,$title,$selection); ?>
         <?php if( ! empty( $settings['support_tags'] ) ) : ?>
             <div class="field textfield" id="row-tags">
                 <label for="url">Tags</label>
@@ -541,6 +545,7 @@ wp_enqueue_style( 'jquery-ui' );
         var tags            = document.getElementById('row-tags').offsetHeight;
         height = height - tags;
         <?php endif; ?>
+        <?php do_action(linkmarklet-js); ?>
         document.getElementById('content').style.height = height + 'px';
     }
     reposition();


### PR DESCRIPTION
Created some hooks for extendability with other plugins:
1. linkmarklet-pre-post
   called before processing the post-update. It allows all kinds of filtering, posting to custom post types, additional meta fields…
2. linkmarklet-after-post: called after posting the new entry. Can trigger any event after post update.
3. linkmarklet-form
   Allows adding new input fields to the bookmarklet form.
4. linkmarklet-js
   Allows extending the javascript of the form

There could be more hooks that make sense but these are the ones that I needed or that I could think that would be useful.
